### PR TITLE
allow to push defaults during flags preload

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ examples/local_config.py
 .lets
 .pdm.toml
 __pypackages__
+.DS_Store

--- a/README.rst
+++ b/README.rst
@@ -27,6 +27,21 @@ Server consists of two services:
 
   - grpclib_ + hiku_
 
+Installation
+~~~~~~~~~~~~
+
+To install client library for synchronous app:
+
+.. code-block:: shell
+
+    $ pip install featureflags-client grpcio
+
+To install client library for asynchronous app:
+
+.. code-block:: shell
+
+    $ pip install featureflags-client grpclib
+
 Development
 ~~~~~~~~~~~
 

--- a/client/featureflags/client/flags.py
+++ b/client/featureflags/client/flags.py
@@ -225,3 +225,12 @@ class Client:
         finally:
             if tracer is not None:
                 self._manager.add_trace(tracer)
+
+    def preload(self, timeout=None):
+        """Preload flags from server.
+        This method syncs all flags with server"""
+        self._manager.preload(timeout=timeout, defaults=self._defaults)
+
+    async def preload_async(self, timeout=None):
+        """Async version of `preload` method"""
+        await self._manager.preload(timeout=timeout, defaults=self._defaults)

--- a/client/featureflags/client/flags.py
+++ b/client/featureflags/client/flags.py
@@ -95,6 +95,15 @@ class StatsCollector:
                 ))
         return stats
 
+    @staticmethod
+    def from_defaults(defaults):
+        interval_pb = Timestamp()
+        interval_pb.FromDatetime(datetime.utcnow())
+        return [
+            FlagUsage(name=name, interval=interval_pb, positive_count=0, negative_count=0)
+            for name in defaults
+        ]
+
 
 class Tracer:
     """


### PR DESCRIPTION
Mananger will sync all flags to server if `defaults` are passed to `preload`.

Example:

```python

class Defaults:
    MY_FLAG = False

manager = SyncManager(...)
client = Client(Defaults, manager)

client.preload(timeout=5)
```

In the example above, we are calling `preload` on client instead of manager. `client.preload` passes defaults to `manager.preload`.

This is the same as 

```
manager = SyncManager(...)
client = Client(Defaults, manager)

manager.preload(timeout=5, defaults=client._defaults)
```