### PR TITLE
Allow to run HTTP API server without GRPC server

### DIFF
--- a/featureflags/config.py
+++ b/featureflags/config.py
@@ -92,7 +92,7 @@ class Config(BaseSettings):
     sentry: SentrySettings
 
     app: AppSettings
-    rpc: RpcSettings
+    rpc: RpcSettings | None = None
     http: HttpSettings
 
 

--- a/featureflags/rpc/app.py
+++ b/featureflags/rpc/app.py
@@ -36,6 +36,10 @@ async def create_server(
 
 
 async def main() -> None:
+
+    if config.rpc is None:
+        raise ValueError("GRPC configuration is not set, check your config")
+
     async with contextlib.AsyncExitStack() as stack:
         container = Container()
         await container.init_resources()


### PR DESCRIPTION
to simplify deployment it's possible now to run only HTTP API server without starting GRPC server  