### PR TITLE
Fix OIDC login crash from naive/aware datetime mismatch

### DIFF
--- a/featureflags/web/api/oidc.py
+++ b/featureflags/web/api/oidc.py
@@ -18,7 +18,7 @@ import hashlib
 import json
 import logging
 import secrets
-from datetime import UTC, datetime
+from datetime import datetime
 from urllib.parse import quote
 
 import aiopg.sa
@@ -227,7 +227,7 @@ async def oidc_callback(
         )
 
     session = user_session.get()
-    now = datetime.now(UTC)
+    now = datetime.utcnow()
     expiration_time = now + AUTH_SESSION_TTL
     async with db_engine.acquire() as conn:
         await conn.execute(


### PR DESCRIPTION
Signing in through OIDC (e.g. Google) returns HTTP 500 on `GET /oidc/{provider}/callback`:

```
TypeError: can't compare offset-naive and offset-aware datetimes
  File ".../featureflags/services/auth.py", line 111, in get_access_token
    "exp": min(self.session_exp, datetime.utcnow() + ACCESS_TOKEN_TTL),
```

**Cause.** The OIDC callback built the session expiry with an aware datetime (`datetime.now(UTC)`), while the rest of the auth code uses naive UTC — `get_access_token`, the LDAP login path (`graph/actions.py`), and the `TIMESTAMP` columns. `get_access_token` then evaluates `min(session_exp, datetime.utcnow() + ...)`, which raises when one operand is aware and the other naive. The OIDC callback was the only place in the codebase creating an aware datetime, so it was the only flow that hit this.

**Fix.** Use naive `datetime.utcnow()` in the callback to match the rest of the codebase, and drop the now-unused `UTC` import. This is consistent with existing usage (`DTZ003` is already in the ruff ignore list).

Validated by deploying a patched build to a dev environment: Google login now completes and the session cookie is set.
