### PR TITLE
Add flag_state gauge metric tracking flag state changes

### DIFF
--- a/featureflags/graph/actions.py
+++ b/featureflags/graph/actions.py
@@ -6,7 +6,7 @@ from sqlalchemy import or_, select, update
 from sqlalchemy.dialects.postgresql import insert
 
 from featureflags.graph.constants import AUTH_SESSION_TTL
-from featureflags.graph.metrics import track
+from featureflags.graph.metrics import set_flag_state_metric, track
 from featureflags.graph.types import (
     Action,
     AddCheckOp,
@@ -35,6 +35,22 @@ from featureflags.models import (
 from featureflags.services.auth import UserSession, auth_required
 from featureflags.services.ldap import BaseLDAP
 from featureflags.utils import select_scalar
+
+
+async def get_flag_metric_labels(
+    flag_uuid: UUID, *, conn: SAConnection
+) -> tuple[str, str] | None:
+    result = await conn.execute(
+        select(
+            [Flag.name.label("flag_name"), Project.name.label("project_name")]
+        )
+        .select_from(
+            Flag.__table__.join(Project.__table__, Flag.project == Project.id)
+        )
+        .where(Flag.id == flag_uuid)
+    )
+    row = await result.first()
+    return (row.flag_name, row.project_name) if row else None
 
 
 @track
@@ -109,6 +125,10 @@ async def enable_flag(
     dirty.by_flag.add(flag_uuid)
     changes.add(flag_uuid, Action.ENABLE_FLAG)
 
+    labels = await get_flag_metric_labels(flag_uuid, conn=conn)
+    if labels:
+        set_flag_state_metric(*labels, enabled=True)
+
 
 @auth_required
 @track
@@ -129,6 +149,10 @@ async def disable_flag(
     )
     dirty.by_flag.add(flag_uuid)
     changes.add(flag_uuid, Action.DISABLE_FLAG)
+
+    labels = await get_flag_metric_labels(flag_uuid, conn=conn)
+    if labels:
+        set_flag_state_metric(*labels, enabled=False)
 
 
 @auth_required

--- a/featureflags/graph/metrics.py
+++ b/featureflags/graph/metrics.py
@@ -1,6 +1,6 @@
 from collections.abc import Callable
 
-from prometheus_client import Counter, Histogram
+from prometheus_client import Counter, Gauge, Histogram
 
 from featureflags.metrics import wrap_metric
 
@@ -28,6 +28,16 @@ GRAPH_PULL_ERRORS_COUNTER = Counter(
     "Graph pull errors count",
     [],
 )
+
+FLAG_STATE_GAUGE = Gauge(
+    "flag_state",
+    "Feature flag state (1 - enabled, 0 - disabled)",
+    ["flag", "project"],
+)
+
+
+def set_flag_state_metric(flag: str, project: str, enabled: bool) -> None:
+    FLAG_STATE_GAUGE.labels(flag=flag, project=project).set(int(enabled))
 
 
 def track(func: Callable) -> Callable:

--- a/featureflags/tests/test_actions.py
+++ b/featureflags/tests/test_actions.py
@@ -2,6 +2,7 @@ from datetime import datetime, timedelta
 
 import faker
 import pytest
+from prometheus_client import REGISTRY
 from sqlalchemy import and_, exists, func, select
 
 from featureflags.graph.actions import (
@@ -69,6 +70,12 @@ from featureflags.tests.state import (
 from featureflags.utils import select_scalar
 
 f = faker.Faker()
+
+
+def get_flag_state_metric(flag, project):
+    return REGISTRY.get_sample_value(
+        "flag_state", {"flag": flag.name, "project": project.name}
+    )
 
 
 async def get_version(project, *, conn):
@@ -288,7 +295,8 @@ async def test_switching_flag(
     after,
     action_type,
 ):
-    flag = await mk_flag(db_engine, enabled=before)
+    project = await mk_project(db_engine)
+    flag = await mk_flag(db_engine, enabled=before, project=project)
     assert await check_flag(flag.id, conn=conn) == before
 
     await action(
@@ -300,6 +308,7 @@ async def test_switching_flag(
     assert dirty_projects.by_flag == {flag.id}
     assert changes.get_actions() == [(flag.id, [action_type])]
     assert await check_flag(flag.id, conn=conn) is after
+    assert get_flag_state_metric(flag, project) == int(after)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## What changed

Adds a Prometheus `Gauge` named `flag_state` with two labels — `flag` and `project` — that is set every time a flag's state changes:

- `enable_flag` sets the gauge to **1**
- `disable_flag` sets the gauge to **0**

Since the graph actions only receive the flag UUID, a new `get_flag_metric_labels()` helper in `featureflags/graph/actions.py` joins `flag` to `project` to resolve the human-readable names used as label values.

## Why

Makes the current state of feature flags observable in Prometheus/Grafana, so dashboards and alerts can track when and which flags are toggled per project.

## Notes for reviewers

- `reset_flag` / `delete_flag` intentionally do not touch the gauge: removing series is only best-effort in a per-process registry (other replicas would keep theirs anyway), so the series simply keeps its last value. This keeps the scope to explicit enable/disable transitions.
- The gauge is set after the `UPDATE` executes but inside the surrounding transaction, matching how the existing action metrics behave; a rollback after the action could briefly leave the gauge ahead of the database.
- Tests: `test_switching_flag` now asserts the gauge value matches the new flag state.
- Verified: full suite (83 passed) plus ruff/black/mypy clean on the changed files.