### PR TITLE
Update changelogs with releases 1.24.1 through 1.26.0rc3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,74 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Removed
+- **gRPC Server**: Removed the gRPC server, protobuf definitions and related dependencies; the gRPC API is superseded by the HTTP API
+  - Removed `featureflags/rpc/` (server, servicer, container, db sync, metrics) and the `rpc` CLI command
+  - Removed `featureflags/protobuf/` (`.proto` files and generated modules) and `graph/proto_adapter.py`
+  - Removed `grpclib`, `grpcio`, `protobuf` and `types-protobuf` dependencies
+  - Removed the `rpc` service from docker-compose, `grpc_health_probe` from the Dockerfile, rpc config sections and gRPC docs
+
+## [1.26.0rc3] - 2026-06-10
+
+### Added
+- **Flag State Metric**: New Prometheus gauge `flag_state` with `flag` and `project` labels, set to 1/0 whenever a flag is enabled or disabled
+
+## [1.26.0rc2] - 2026-05-21
+
+### Added
+- **Env Var Substitution in Config**: Support resolving config values from environment variables
+  - OIDC `client_secret` can be resolved from an env var via `$VAR` indirection
+  - Support for `${VAR}` and inline env-var substitution; invalid env var names pass through unchanged
+
+## [1.26.0rc1] - 2026-05-21
+
+### Added
+- **OIDC Authentication**: New OpenID Connect authentication support
+  - New `featureflags/services/oidc_auth.py` service and `/oidc` web API endpoints
+  - `oidc_subject` column added to auth user (database migration included)
+  - UI login flow updated to support OIDC
+
+## [1.25.0] - 2026-01-09
+
+### Added
+- **Project Label in Metrics**: Added `project` label to gRPC and HTTP handler metrics to distinguish between projects
+- **Prometheus Metrics Documentation**: New documentation page describing exposed Prometheus metrics
+
+### Internal
+- Restructured and updated documentation
+- Updated pdm and lock file
+
+## [1.24.4] - 2025-10-10
+
+### Fixed
+- **Value Condition Override Input**: Made value condition override input single per condition
+  - Fixed bug with editing an existing condition (order of `disable_condition` and `add_condition` operations)
+  - Fixed bug with the position of the first condition in the list
+  - Improved inputs layout with Flex
+
+## [1.24.3] - 2025-10-10
+
+### Internal
+- Updated README
+
+## [1.24.2] - 2025-10-10
+
+### Changed
+- **UI Improvements**: Improved conditions ordering in the UI and made the layout wider
+
+### Fixed
+- Fixed GraphiQL
+
+### Internal
+- Updated getting started docs and added code comments
+
+## [1.24.1] - 2025-08-11
+
+### Internal
+- **Documentation**: Added RST documentation with Read the Docs config and UI image
+
 ## [1.24.0] - 2025-07-29
 
 ### Added

--- a/docs/changelog/server/changes_1.rst
+++ b/docs/changelog/server/changes_1.rst
@@ -1,6 +1,107 @@
 Changes in 1.X
 ==============
 
+Unreleased
+----------
+
+Removed
+~~~~~~~
+
+- **gRPC Server**: Removed the gRPC server, protobuf definitions and related dependencies; the gRPC API is superseded by the HTTP API
+  - Removed ``featureflags/rpc/`` (server, servicer, container, db sync, metrics) and the ``rpc`` CLI command
+  - Removed ``featureflags/protobuf/`` (``.proto`` files and generated modules) and ``graph/proto_adapter.py``
+  - Removed ``grpclib``, ``grpcio``, ``protobuf`` and ``types-protobuf`` dependencies
+  - Removed the ``rpc`` service from docker-compose, ``grpc_health_probe`` from the Dockerfile, rpc config sections and gRPC docs
+
+1.26.0rc3
+---------
+
+Added
+~~~~~
+
+- **Flag State Metric**: New Prometheus gauge ``flag_state`` with ``flag`` and ``project`` labels, set to 1/0 whenever a flag is enabled or disabled
+
+1.26.0rc2
+---------
+
+Added
+~~~~~
+
+- **Env Var Substitution in Config**: Support resolving config values from environment variables
+  - OIDC ``client_secret`` can be resolved from an env var via ``$VAR`` indirection
+  - Support for ``${VAR}`` and inline env-var substitution; invalid env var names pass through unchanged
+
+1.26.0rc1
+---------
+
+Added
+~~~~~
+
+- **OIDC Authentication**: New OpenID Connect authentication support
+  - New ``featureflags/services/oidc_auth.py`` service and ``/oidc`` web API endpoints
+  - ``oidc_subject`` column added to auth user (database migration included)
+  - UI login flow updated to support OIDC
+
+1.25.0
+------
+
+Added
+~~~~~
+
+- **Project Label in Metrics**: Added ``project`` label to gRPC and HTTP handler metrics to distinguish between projects
+- **Prometheus Metrics Documentation**: New documentation page describing exposed Prometheus metrics
+
+Internal
+~~~~~~~~
+
+- Restructured and updated documentation
+- Updated pdm and lock file
+
+1.24.4
+------
+
+Fixed
+~~~~~
+
+- **Value Condition Override Input**: Made value condition override input single per condition
+  - Fixed bug with editing an existing condition (order of ``disable_condition`` and ``add_condition`` operations)
+  - Fixed bug with the position of the first condition in the list
+  - Improved inputs layout with Flex
+
+1.24.3
+------
+
+Internal
+~~~~~~~~
+
+- Updated README
+
+1.24.2
+------
+
+Changed
+~~~~~~~
+
+- **UI Improvements**: Improved conditions ordering in the UI and made the layout wider
+
+Fixed
+~~~~~
+
+- Fixed GraphiQL
+
+Internal
+~~~~~~~~
+
+- Updated getting started docs and added code comments
+
+1.24.1
+------
+
+Internal
+~~~~~~~~
+
+- **Documentation**: Added RST documentation with Read the Docs config and UI image
+
 1.24.0
 ------
 

--- a/docs/changelog/server/index.rst
+++ b/docs/changelog/server/index.rst
@@ -4,5 +4,4 @@ Server Changelog
 .. toctree::
     :maxdepth: 2
 
-    changes_2
     changes_1


### PR DESCRIPTION
## What changed

- **CHANGELOG.md**: added entries for every release since 1.24.0, reconstructed from git tags and commit history:
  - **Unreleased** — gRPC server, protobuf definitions and related dependencies removed (#68)
  - **1.26.0rc3** — `flag_state` Prometheus gauge with `flag`/`project` labels
  - **1.26.0rc2** — env-var substitution in config (`$VAR` indirection for OIDC `client_secret`, `${VAR}` and inline substitution)
  - **1.26.0rc1** — OIDC authentication support
  - **1.25.0** — `project` label on handler metrics, Prometheus metrics docs
  - **1.24.1–1.24.4** — RST docs setup, UI conditions ordering/layout, GraphiQL fix, value condition override input fixes
- **docs/changelog/server/changes_1.rst**: mirrored the same entries in the Sphinx docs changelog, which also stopped at 1.24.0
- **docs/changelog/server/index.rst**: dropped the dangling `changes_2` toctree reference — c4ec1da added it ("add 1.25 changelog") but the file was never committed, leaving a broken reference in the docs build

## Why

The changelogs were five releases behind; the docs changelog additionally had a broken toctree entry.

## Notes for reviewers

- New entries were folded into `changes_1.rst` ("Changes in 1.X") rather than creating `changes_2.rst`, since all releases are still 1.x.
- Verified with `pdm run docs` (sphinx-build): build succeeds with zero warnings or errors.
- Release dates are taken from tag commit dates; entry contents summarize the commit messages between tags.