### PR TITLE
Create GitHub releases automatically on version tags

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -42,3 +42,44 @@ jobs:
 
     - name: Upload package to pypi.org
       run: pdm publish -u "__token__" -P ${{ secrets.PYPI_TOKEN }}
+
+  github-release:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+
+    - name: Create GitHub release
+      env:
+        GH_TOKEN: ${{ github.token }}
+      run: |
+        TAG="${GITHUB_REF_NAME}"
+        VERSION="${TAG#v}"
+
+        if gh release view "$TAG" >/dev/null 2>&1; then
+          echo "Release $TAG already exists, skipping"
+          exit 0
+        fi
+
+        # Extract this version's section from CHANGELOG.md
+        awk -v ver="$VERSION" '
+          /^## \[/ { if (found) exit; if (index($0, "## [" ver "]") == 1) found = 1; next }
+          found { print }
+        ' CHANGELOG.md > /tmp/notes.md
+
+        ARGS=(--title "$TAG" --verify-tag)
+
+        # PEP 440 pre-releases (rc/a/b/dev suffixes) are not plain X.Y.Z
+        if [[ ! "$VERSION" =~ ^[0-9]+(\.[0-9]+)*$ ]]; then
+          ARGS+=(--prerelease)
+        fi
+
+        if grep -q '[^[:space:]]' /tmp/notes.md; then
+          ARGS+=(--notes-file /tmp/notes.md)
+        else
+          ARGS+=(--generate-notes)
+        fi
+
+        gh release create "$TAG" "${ARGS[@]}"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Removed `grpclib`, `grpcio`, `protobuf` and `types-protobuf` dependencies
   - Removed the `rpc` service from docker-compose, `grpc_health_probe` from the Dockerfile, rpc config sections and gRPC docs
 
+### Internal
+- Release workflow now creates a GitHub Release for each pushed `v*` tag, with notes taken from the matching `CHANGELOG.md` section (auto-generated when missing) and pre-release marking for non-final versions
+
 ## [1.26.0rc3] - 2026-06-10
 
 ### Added

--- a/docs/development.rst
+++ b/docs/development.rst
@@ -40,6 +40,12 @@ To release package:
 
 - ``lets release 1.0.0 --message="Added feature"``
 
+This pushes a ``v*`` tag, which triggers the release workflow: the package is
+published to PyPI and a GitHub Release is created automatically. Release notes
+are taken from the version's section in ``CHANGELOG.md`` (or auto-generated
+from merged PRs when the section is missing), so update the changelog before
+releasing. Non-final versions (e.g. ``1.26.0rc1``) are marked as pre-releases.
+
 Pre-commit
 
 ``./scripts/enable-hooks.sh``


### PR DESCRIPTION
## What changed

Added a `github-release` job to the existing tag-triggered release workflow. On every `v*` tag push (i.e. each `lets release`), alongside the PyPI publish, it now creates a GitHub Release using the built-in `gh` CLI:

- **Notes from the changelog**: extracts the `## [<version>]` section from `CHANGELOG.md`; falls back to GitHub's auto-generated notes (from merged PRs) when the section is missing
- **Pre-release marking**: versions that aren't plain `X.Y.Z` (e.g. `1.26.0rc1`) are flagged as pre-releases
- **Idempotent**: skips if the release already exists, so workflow re-runs (e.g. after a PyPI failure) don't fail
- Runs independently of the `deploy` job and uses the workflow's own `github.token` with `contents: write` scoped to the job — no new secrets required

Also documented the behavior in `docs/development.rst` and `CHANGELOG.md`.

## Why

GitHub Releases were created manually up to v1.1.3 (2024) and abandoned since; all newer versions exist only as bare tags. This automates them so each release gets a browsable page with its changelog section.

## Notes for reviewers

- No third-party actions used — the logic is ~20 lines of shell, avoiding a supply-chain dependency in a workflow with write permissions
- Changelog extraction and argument composition were tested locally against the real `CHANGELOG.md` for three representative tags: `v1.25.0` (final, has changelog section → notes from file), `v1.26.0rc4` (rc, no section → pre-release with generated notes), `v1.15` (old final, no section → generated notes)
- Tags between `v1.2` and `v1.26.0rc4` are not backfilled; this only affects future tags