### PR TITLE
Redirect to root page after project deletion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   replica in a second datacenter. Unknown projects are served as an empty
   state with `version: 0` instead of failing.
 
+### Fixed
+- **UI**: Redirect to the root page right after a project is deleted ([#61](https://github.com/evo-company/featureflags/issues/61)). The projects list is refreshed via Apollo cache instead of a delayed full page reload, and the deleted project is cleared from the selection state.
+
 ### Removed
 - **gRPC Server**: Removed the gRPC server, protobuf definitions and related dependencies; the gRPC API is superseded by the HTTP API
   - Removed `featureflags/rpc/` (server, servicer, container, db sync, metrics) and the `rpc` CLI command

--- a/ui/src/Dashboard/Dashboard.jsx
+++ b/ui/src/Dashboard/Dashboard.jsx
@@ -68,6 +68,8 @@ function Dashboard({ projects }) {
     if (projectFromQuery) {
       setSelected(projectFromQuery);
       scrollToProject(projectFromQuery);
+    } else {
+      setSelected('');
     }
   }, [projectFromQuery]);
 

--- a/ui/src/Dashboard/Settings.jsx
+++ b/ui/src/Dashboard/Settings.jsx
@@ -2,7 +2,7 @@ import { useNavigate } from "react-router-dom";
 import { useState } from "react";
 import { Button, message, Space, Typography, Modal, Card } from 'antd';
 import { useMutation } from '@apollo/client';
-import { DELETE_PROJECT_MUTATION } from "./queries";
+import { DELETE_PROJECT_MUTATION, PROJECTS_QUERY } from "./queries";
 import { HeaderTabs } from "./Tabs";
 
 
@@ -65,26 +65,28 @@ export const SettingsContainer = ({ projectName, projectsMap }) => {
   const navigate = useNavigate();
 
   const [deleteProject] = useMutation(DELETE_PROJECT_MUTATION, {
-    variables: { id: project.id },
+    variables: { id: project?.id },
+    refetchQueries: [{ query: PROJECTS_QUERY }],
     onCompleted: (data) => {
       if (data.deleteProject && data.deleteProject.error) {
         message.error(data.deleteProject.error);
       } else {
-        message.success(`Project "${project.name}" removed successfully`);
-        setTimeout(() => {
-          navigate(`/`);
-          window.location.reload();
-        }, 2000);
+        message.success(`Project "${projectName}" removed successfully`);
+        navigate(`/`);
       }
     },
     onError: (error) => {
-      message.error(`Error removing project "${project.name}": ${error.message}`);
+      message.error(`Error removing project "${projectName}": ${error.message}`);
     }
   });
 
   const handleRemove = () => {
     deleteProject();
   };
+
+  if (!project) {
+    return null;
+  }
 
   return (
     <View>


### PR DESCRIPTION
Fixes #61

## What changed

- **`ui/src/Dashboard/Settings.jsx`**: on successful project deletion the UI now navigates to the root page immediately and refreshes the projects list through Apollo (`refetchQueries: [PROJECTS_QUERY]`), replacing the old flow of waiting 2 seconds and then calling `navigate('/')` immediately followed by `window.location.reload()`. Also added a `if (!project) return null` guard so the settings pane can't crash on `project.id` if the project disappears from `projectsMap` while it is still mounted.
- **`ui/src/Dashboard/Dashboard.jsx`**: the `selected` project state is now cleared when the `project` query param is removed from the URL, so the deleted project doesn't linger as a stale selection on the root page (also fixes back-button behavior).
- **`CHANGELOG.md`**: entry under Unreleased → Fixed.

## Why

The old `navigate('/') + window.location.reload()` combo raced the hash update against a full page reload behind a 2-second timer, which could leave the user on the stale settings page of the deleted project instead of the root page. A plain SPA navigation plus a cache refetch removes the race, the reload jank and the dead 2-second wait entirely.

## How it was verified

Ran the full stack locally (postgres + LDAP + web via docker compose, projects seeded via SQL) and exercised the real deletion flow in a browser against both the vite dev server and the production bundle served by the backend:

- URL goes to `#/` (root) instantly after confirming deletion
- the "Project … removed successfully" toast stays visible on the root page
- the sidebar updates in place with no page reload (verified via a JS marker surviving the navigation)
- no new console errors