### PR TITLE
Show percent operator only for number variables

### DIFF
--- a/ui/src/Dashboard/constants.js
+++ b/ui/src/Dashboard/constants.js
@@ -29,7 +29,6 @@ export const TYPES = {
             Operator.LESS_OR_EQUAL,
             Operator.GREATER_THAN,
             Operator.GREATER_OR_EQUAL,
-            Operator.PERCENT,
             Operator.CONTAINS,
             Operator.REGEXP,
             Operator.WILDCARD


### PR DESCRIPTION
## What changed

Removed `Operator.PERCENT` from the STRING type's operator list in `ui/src/Dashboard/constants.js`, so the percent operator is now offered only for NUMBER variables.

## Why

The percent operator only makes sense for integer values, but the operator dropdown offered it for string variables as well. Since all operator dropdowns (Check, ValueCheck, Flag, Value) build their options from the single `TYPES` map, this one-line change covers the whole UI.

## Notes for reviewers

Existing checks already saved with percent on a string variable keep working server-side, but their operator dropdown will display the raw value `7` instead of the "percent" label since the option is no longer in the list.